### PR TITLE
Fix metal selector names in learn_metal examples

### DIFF
--- a/learn_metal/01-primitive/01-primitive.odin
+++ b/learn_metal/01-primitive/01-primitive.odin
@@ -49,7 +49,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->setFragmentFunction(fragment_function)
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 

--- a/learn_metal/02-argbuffers/02-argbuffers.odin
+++ b/learn_metal/02-argbuffers/02-argbuffers.odin
@@ -53,7 +53,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->setFragmentFunction(fragment_function)
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 

--- a/learn_metal/03-animation/03-animation.odin
+++ b/learn_metal/03-animation/03-animation.odin
@@ -66,7 +66,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->setFragmentFunction(fragment_function)
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 

--- a/learn_metal/04-instancing/04-instancing.odin
+++ b/learn_metal/04-instancing/04-instancing.odin
@@ -69,7 +69,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->setFragmentFunction(fragment_function)
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 

--- a/learn_metal/05-perspective/05-perspective.odin
+++ b/learn_metal/05-perspective/05-perspective.odin
@@ -84,7 +84,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 	desc->setDepthAttachmentPixelFormat(.Depth16Unorm)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 
@@ -255,7 +255,7 @@ metal_main :: proc() -> (err: ^NS.Error) {
 				depth_texture->release()
 			}
 
-			depth_texture = device->newTexture(desc)
+			depth_texture = device->newTextureWithDescriptor(desc)
 		}
 
 		drawable := swapchain->nextDrawable()

--- a/learn_metal/06-lighting/06-lighting.odin
+++ b/learn_metal/06-lighting/06-lighting.odin
@@ -113,7 +113,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 	desc->setDepthAttachmentPixelFormat(.Depth16Unorm)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 
@@ -323,7 +323,7 @@ metal_main :: proc() -> (err: ^NS.Error) {
 				depth_texture->release()
 			}
 
-			depth_texture = device->newTexture(desc)
+			depth_texture = device->newTextureWithDescriptor(desc)
 		}
 
 

--- a/learn_metal/07-texturing/07-texturing.odin
+++ b/learn_metal/07-texturing/07-texturing.odin
@@ -123,7 +123,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 	desc->setDepthAttachmentPixelFormat(.Depth16Unorm)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 
@@ -189,7 +189,7 @@ build_texture :: proc(device: ^MTL.Device) -> ^MTL.Texture {
 	desc->setStorageMode(.Managed)
 	desc->setUsage({.ShaderRead})
 
-	texture := device->newTexture(desc)
+	texture := device->newTextureWithDescriptor(desc)
 
 	texture_data := make([][4]u8, tw*th, context.temp_allocator)
 	for y in 0..<th {
@@ -369,7 +369,7 @@ metal_main :: proc() -> (err: ^NS.Error) {
 				depth_texture->release()
 			}
 
-			depth_texture = device->newTexture(desc)
+			depth_texture = device->newTextureWithDescriptor(desc)
 		}
 
 

--- a/learn_metal/08-compute/08-compute.odin
+++ b/learn_metal/08-compute/08-compute.odin
@@ -126,7 +126,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 	desc->setDepthAttachmentPixelFormat(.Depth16Unorm)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 
@@ -190,7 +190,7 @@ build_texture :: proc(device: ^MTL.Device) -> ^MTL.Texture {
 	desc->setStorageMode(.Managed)
 	desc->setUsage({.ShaderRead, .ShaderWrite})
 
-	return device->newTexture(desc)
+	return device->newTextureWithDescriptor(desc)
 }
 
 build_compute_pipeline :: proc(device: ^MTL.Device) -> (pso: ^MTL.ComputePipelineState, err: ^NS.Error) {
@@ -420,7 +420,7 @@ metal_main :: proc() -> (err: ^NS.Error) {
 				depth_texture->release()
 			}
 
-			depth_texture = device->newTexture(desc)
+			depth_texture = device->newTextureWithDescriptor(desc)
 		}
 
 

--- a/learn_metal/09-compute-to-render/09-compute-to-render.odin
+++ b/learn_metal/09-compute-to-render/09-compute-to-render.odin
@@ -126,7 +126,7 @@ build_shaders :: proc(device: ^MTL.Device) -> (library: ^MTL.Library, pso: ^MTL.
 	desc->colorAttachments()->object(0)->setPixelFormat(.BGRA8Unorm_sRGB)
 	desc->setDepthAttachmentPixelFormat(.Depth16Unorm)
 
-	pso = device->newRenderPipelineState(desc) or_return
+	pso = device->newRenderPipelineStateWithDescriptor(desc) or_return
 	return
 }
 
@@ -191,7 +191,7 @@ build_texture :: proc(device: ^MTL.Device) -> ^MTL.Texture {
 	desc->setStorageMode(.Managed)
 	desc->setUsage({.ShaderRead, .ShaderWrite})
 
-	return device->newTexture(desc)
+	return device->newTextureWithDescriptor(desc)
 }
 
 build_compute_pipeline :: proc(device: ^MTL.Device) -> (pso: ^MTL.ComputePipelineState, err: ^NS.Error) {
@@ -442,7 +442,7 @@ metal_main :: proc() -> (err: ^NS.Error) {
 				depth_texture->release()
 			}
 
-			depth_texture = device->newTexture(desc)
+			depth_texture = device->newTextureWithDescriptor(desc)
 		}
 
 


### PR DESCRIPTION
updating examples to reflect a recent change to `newTexture` and `newRenderPipeline`