### PR TITLE
Fix SDL2 OpenGL example

### DIFF
--- a/sdl2/opengl/sdl2_opengl_demo.odin
+++ b/sdl2/opengl/sdl2_opengl_demo.odin
@@ -7,21 +7,32 @@ import "core:time"
 import SDL "vendor:sdl2"
 import gl "vendor:OpenGL"
 
+GL_VERSION_MAJOR :: 3
+GL_VERSION_MINOR :: 3
+
 main :: proc() {
 	WINDOW_WIDTH  :: 854
 	WINDOW_HEIGHT :: 480
-	
+
+	SDL.Init({.VIDEO})
+	defer SDL.Quit()
+
 	window := SDL.CreateWindow("Odin SDL2 Demo", SDL.WINDOWPOS_UNDEFINED, SDL.WINDOWPOS_UNDEFINED, WINDOW_WIDTH, WINDOW_HEIGHT, {.OPENGL})
 	if window == nil {
 		fmt.eprintln("Failed to create window")
 		return
 	}
 	defer SDL.DestroyWindow(window)
-	
+
+	SDL.GL_SetAttribute(.CONTEXT_PROFILE_MASK,  i32(SDL.GLprofile.CORE))
+	SDL.GL_SetAttribute(.CONTEXT_MAJOR_VERSION, GL_VERSION_MAJOR)
+	SDL.GL_SetAttribute(.CONTEXT_MINOR_VERSION, GL_VERSION_MINOR)
+
 	gl_context := SDL.GL_CreateContext(window)
-	SDL.GL_MakeCurrent(window, gl_context)
+	defer SDL.GL_DeleteContext(gl_context)
+
 	// load the OpenGL procedures once an OpenGL context has been established
-	gl.load_up_to(3, 3, SDL.gl_set_proc_address)
+	gl.load_up_to(GL_VERSION_MAJOR, GL_VERSION_MINOR, SDL.gl_set_proc_address)
 	
 	// useful utility procedures that are part of vendor:OpenGl
 	program, program_ok := gl.load_shaders_source(vertex_source, fragment_source)

--- a/sdl2/opengl/sdl2_opengl_demo.odin
+++ b/sdl2/opengl/sdl2_opengl_demo.odin
@@ -49,6 +49,7 @@ main :: proc() {
 	
 	vao: u32
 	gl.GenVertexArrays(1, &vao); defer gl.DeleteVertexArrays(1, &vao)
+	gl.BindVertexArray(vao)
 	
 	// initialization of OpenGL buffers
 	vbo, ebo: u32


### PR DESCRIPTION
The example fails to run on my computer without these changes. I realize this is platform-dependent problem, but I believe these changes should be generally more inclusive.