### PR TITLE
Fix `for sdl2.PollEvent(&event)` for new sdl2 bindings

### DIFF
--- a/sdl2/chase_in_space/chase_in_space.odin
+++ b/sdl2/chase_in_space/chase_in_space.odin
@@ -185,7 +185,7 @@ main :: proc() {
 
 	for {
 		event: sdl2.Event
-		for sdl2.PollEvent(&event) > 0 {
+		for sdl2.PollEvent(&event) {
 			#partial switch event.type {
 			case .QUIT:
 				return


### PR DESCRIPTION
Fix since the sdl2 bindings changed to return a `b32`