### PR TITLE
removed GetWindowSurface (avoid "Renderer already associated with window")…

### DIFF
--- a/sdl2/hellope/hellope.odin
+++ b/sdl2/hellope/hellope.odin
@@ -117,12 +117,6 @@ init_sdl :: proc() -> (ok: bool) {
 		return false
 	}
 
-	ctx.surface = sdl2.GetWindowSurface(ctx.window)
-	if ctx.surface == nil {
-		log.errorf("sdl2.GetWindowSurface failed.")
-		return false
-	}
-
 	ctx.renderer = sdl2.CreateRenderer(ctx.window, -1, {.ACCELERATED, .PRESENTVSYNC})
 	if ctx.renderer == nil {
 		log.errorf("sdl2.CreateRenderer failed.")


### PR DESCRIPTION
I tried the hellope example on Archlinux (sdl2 is 2.24.0)

I got:

``
[ERROR] --- [2022-08-26 07:40:40] [hellope.odin:128:init_sdl()]  sdl2.CreateRenderer failed.
[ERROR] --- [2022-08-26 07:40:40] [hellope.odin:287:main()]  Initialization failed.
``

Chaning the example to:

``
        if ctx.renderer == nil {
                log.errorf("sdl2.CreateRenderer failed.: {}", sdl2.GetError())
                return false
        }
``
yields:

``
[ERROR] --- [2022-08-26 07:50:03] [hellope.odin:128:init_sdl()]  sdl2.CreateRenderer failed.: Renderer already associated with window
``

I just removed the call to GetWindowSurface and the example worked fine..

Please note: I am a complete newbie if it comes to Odin, SDL2 or graphical
programming. :-)
