### PR TITLE
os.read instead of io.read

### DIFF
--- a/by_example/read_console_input/read_console_input.odin
+++ b/by_example/read_console_input/read_console_input.odin
@@ -6,8 +6,8 @@ import "core:os"
 main :: proc() {
 	buf: [256]byte
 	fmt.println("Please enter some text:")
-	n, err := io.read(buf[:])
-	if err != nil {
+	n, err := os.read(os.stdin, buf[:])
+	if err < 0 {
 		// Handle error
 		return
 	}


### PR DESCRIPTION
line 9 had a io.read instead of os.read, also the read function expects 2 arguments so i put os.stdin. Also the returned error should not be compared against nil because it is a int32 type.