### PR TITLE
Fix sdl2 hellope example using Makefile

### DIFF
--- a/sdl2/hellope/Makefile
+++ b/sdl2/hellope/Makefile
@@ -1,4 +1,4 @@
 all: run
 
 run:
-	odin run hellope.odin -show-timings -vet -out:hellope
+	odin run . -show-timings -vet -out:hellope


### PR DESCRIPTION
Using latest Odin release and running:

```
$ make
odin run hellope.odin -show-timings -vet -out:hellope ERROR: `odin run` takes a package as its first argument.
Did you mean `odin run hellope.odin -file`?
The `-file` flag tells it to treat a file as a self-contained package. make: *** [Makefile:4: run] Error 1
```

For being consistent with build.bat, replace the filename in Makefile with '.'