### PR TITLE
Fixed out of bounds errors during painting (game_of_life)

### DIFF
--- a/raylib/game_of_life/game_of_life.odin
+++ b/raylib/game_of_life/game_of_life.odin
@@ -157,6 +157,12 @@ process_user_input :: proc(user_input: ^User_Input, window: Window, world: World
     mouse_x := i32((m_pos[0] / f32(window.width)) * f32(world.width))
     mouse_y := i32((m_pos[1] / f32(window.height)) * f32(world.height))
 
+    //Keep in bounds while painting with torus wrapping
+    if user_input.left_mouse_clicked || user_input.right_mouse_clicked {
+        mouse_x %%= world.width
+        mouse_y %%= world.height
+    }
+
     user_input^ = User_Input{
         left_mouse_clicked    = rl.IsMouseButtonDown(.LEFT),
         right_mouse_clicked   = rl.IsMouseButtonDown(.RIGHT),


### PR DESCRIPTION
There were of bounds errors if the mouse was clicked and dragged out of window at top left and bottom edge. Behavior now in-line with count_neighbors (double modulo operator to wrap coordinates)