### PR TITLE
Fix text not showing when clipped in raylib/microui example

### DIFF
--- a/raylib/microui/microui_raylib_demo.odin
+++ b/raylib/microui/microui_raylib_demo.odin
@@ -167,8 +167,6 @@ render :: proc "contextless" (ctx: ^mu.Context) {
 		return {in_color.r, in_color.g, in_color.b, in_color.a}
 	}
 
-	height := rl.GetScreenHeight()
-
 	rl.BeginTextureMode(state.screen_texture)
 	rl.EndScissorMode()
 	rl.ClearBackground(to_rl_color(state.bg))
@@ -194,7 +192,7 @@ render :: proc "contextless" (ctx: ^mu.Context) {
 			y := cmd.rect.y + (cmd.rect.h - src.h)/2
 			render_texture(state.screen_texture, &rl.Rectangle {f32(x), f32(y), 0, 0}, src, to_rl_color(cmd.color))
 		case ^mu.Command_Clip:
-			rl.BeginScissorMode(cmd.rect.x, height - (cmd.rect.y + cmd.rect.h), cmd.rect.w, cmd.rect.h)
+			rl.BeginScissorMode(cmd.rect.x, cmd.rect.y, cmd.rect.w, cmd.rect.h)
 		case ^mu.Command_Jump:
 			unreachable()
 		}


### PR DESCRIPTION
<!-- use [x] to mark the item as done, or just click it -->

- [ ] Have you added the example to the CI at `.github/workflows/check.yml`?

As the title says, the example didn't show long text correctly, so by moving the window around i figured that the clipping rectangle calculation is upside down.