### PR TITLE
Simplified dir_info example

### DIFF
--- a/dir_info/main.odin
+++ b/dir_info/main.odin
@@ -1,46 +1,53 @@
-package main
+/*
+How to get information about a directory, including which files and directories
+it contains.
+*/
+package dir_info
 
 import "core:fmt"
 import "core:os"
 import "core:path/filepath"
-import "core:strings"
-
-print_file_info :: proc(fi: os.File_Info) {
-	// Split the path into directory and filename
-	_, filename := filepath.split(fi.fullpath)
-
-	SIZE_WIDTH :: 12
-	buf: [SIZE_WIDTH]u8
-
-	// Print size to string backed by buf on stack, no need to free
-	_size := "-" if fi.is_dir else fmt.bprintf(buf[:], "%v", fi.size)
-
-	// Right-justify size for display, heap allocated
-	size := strings.right_justify(_size, SIZE_WIDTH, " ")
-	defer delete(size)
-
-	if fi.is_dir {
-		fmt.printf("%v [%v]\n", size, filename)
-	} else {
-		fmt.printf("%v %v\n", size, filename)
-	}
-}
 
 main :: proc() {
 	cwd := os.get_current_directory()
-	fmt.println("Current working directory:", cwd)
 
+	// Swap `cwd` for some other string to change which folder you're looking at
 	f, err := os.open(cwd)
+
 	defer os.close(f)
 
 	if err != os.ERROR_NONE {
-		// Print error to stderr and exit with errorcode
 		fmt.eprintln("Could not open directory for reading", err)
 		os.exit(1)
 	}
 
+	/*
+	File_Info :: struct {
+		fullpath: string, // allocated
+		name:     string, // uses `fullpath` as underlying data
+		size:     i64,
+		mode:     File_Mode,
+		is_dir:   bool,
+		creation_time:     time.Time,
+		modification_time: time.Time,
+		access_time:       time.Time,
+	}
+
+	(from <odin>/core/os/stat.odin)
+	*/
 	fis: []os.File_Info
-	defer os.file_info_slice_delete(fis) // fis is a slice, we need to remember to free it
+
+	/*
+	This will deallocate `fis` at the end of this scope.
+
+	Note how `fis` is assigned a return value from `os.read_dir`. That's a
+	dynamically allocated slice.
+	
+	Note how it doesn't matter that `fis` hasn't been assigned yet: `defer` will
+	fetch variable `fis` at the end of this scope. It does not fetch the value
+	of that	variable now.
+	*/
+	defer os.file_info_slice_delete(fis)
 
 	fis, err = os.read_dir(f, -1) // -1 reads all file infos
 	if err != os.ERROR_NONE {
@@ -48,8 +55,15 @@ main :: proc() {
 		os.exit(2)
 	}
 
+	fmt.printfln("Current working directory %v contains:", cwd)
+
 	for fi in fis {
-		print_file_info(fi)
+		_, name := filepath.split(fi.fullpath)
+
+		if fi.is_dir {
+			fmt.printfln("%v (directory)", name)
+		} else {
+			fmt.printfln("%v (%v bytes)", name, fi.size)
+		}
 	}
 }
-


### PR DESCRIPTION
<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
