### PR TITLE
Fix learn Metal README links

### DIFF
--- a/metal/learn_metal/README.md
+++ b/metal/learn_metal/README.md
@@ -31,40 +31,40 @@ odin build . -extra-linker-flags:"-L/opt/homebrew/lib"
 
 ## Examples
 
-### [00-window](https://github.com/odin-lang/examples/tree/master/learn_metal/00-window)
+### [00-window](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/00-window)
 
 ![00-window](https://user-images.githubusercontent.com/3338141/163404425-9e41168c-8f7f-4fd7-b7d9-c1c44a1d3870.png)
 
-### [01-primitive](https://github.com/odin-lang/examples/tree/master/learn_metal/01-primitive)
+### [01-primitive](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/01-primitive)
 
 ![01-primitive](https://user-images.githubusercontent.com/3338141/163404549-0ece2502-1890-4bf6-b816-c0de3bfff303.png)
 
-### [02-argbuffers](https://github.com/odin-lang/examples/tree/master/learn_metal/02-argbuffers)
+### [02-argbuffers](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/02-argbuffers)
 
 ![02-argbuffers](https://user-images.githubusercontent.com/3338141/163404646-bbb50869-303a-44d3-b039-1cc2d14b976e.png)
 
-### [03-animation](https://github.com/odin-lang/examples/tree/master/learn_metal/03-animation)
+### [03-animation](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/03-animation)
 
 ![03-animation](https://user-images.githubusercontent.com/3338141/163406377-9bffb411-b0e5-4c8f-b50f-a2fc20abfa55.mp4)
 
-### [04-instancing](https://github.com/odin-lang/examples/tree/master/learn_metal/04-instancing)
+### [04-instancing](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/04-instancing)
 
 ![04-instancing](https://user-images.githubusercontent.com/3338141/163406745-e9e965a9-f187-4dbe-915e-096766a30e17.mp4)
 
-### [05-perspective](https://github.com/odin-lang/examples/tree/master/learn_metal/05-perspective)
+### [05-perspective](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/05-perspective)
 
 ![05-perspective](https://user-images.githubusercontent.com/3338141/163406890-b6e96463-4754-4f7f-b223-95e4dde73be3.mp4)
 
-### [06-lighting](https://github.com/odin-lang/examples/tree/master/learn_metal/06-lighting)
+### [06-lighting](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/06-lighting)
 
 ![06-lighting](https://user-images.githubusercontent.com/3338141/163407030-43389d2f-e4d7-4387-936f-c671722ee1cd.png)
 
-### [07-texturing](https://github.com/odin-lang/examples/tree/master/learn_metal/07-texturing)
+### [07-texturing](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/07-texturing)
 
 ![07-texturing](https://user-images.githubusercontent.com/3338141/163419029-d4b86185-74e3-487e-b22b-68cc676320ed.png)
 
-### [08-compute](https://github.com/odin-lang/examples/tree/master/learn_metal/08-compute)
+### [08-compute](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/08-compute)
 
 ![08-compute](https://user-images.githubusercontent.com/3338141/163422465-329f7530-df4f-4fd0-9a68-cc58ab855179.png)
 
-### [09-compute-to-render](https://github.com/odin-lang/examples/tree/master/learn_metal/09-compute-to-render)
+### [09-compute-to-render](https://github.com/odin-lang/examples/tree/master/metal/learn_metal/09-compute-to-render)


### PR DESCRIPTION
Closes #93 

Checklist before submitting:

This is only a spelling fix, these checklist items were already all done.


- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
