### PR TITLE
add explicit cursor assignment in win32 window example

### DIFF
--- a/win32/open_window/main.odin
+++ b/win32/open_window/main.odin
@@ -11,6 +11,7 @@ main :: proc() {
 		lpfnWndProc = win_proc,
 		lpszClassName = class_name,
 		hInstance = instance,
+		hCursor = win.LoadCursorA(nil, win.IDC_ARROW),
 	}
 
 	class := win.RegisterClassW(&cls)


### PR DESCRIPTION
This fixes an issue where the cursor for win32 windows shows a spinner cursor and a possibility where the drag arrow might become persistent.


Checklist before submitting:
- [x ] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [ x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [ x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x ] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
