### PR TITLE
math/rand - Simple markov chain

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,7 @@ jobs:
           odin check thread/basics $FLAGS
 
           odin check math/noise/draw_texture $FLAGS
-          odin check math/rand/markov/simple_markov $FLAGS
+          odin check math/rand/markov $FLAGS
 
           odin check raylib/game_of_life $FLAGS
           odin check raylib/log $FLAGS

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,6 +57,7 @@ jobs:
           odin check thread/basics $FLAGS
 
           odin check math/noise/draw_texture $FLAGS
+          odin check math/rand/markov/simple_markov $FLAGS
 
           odin check raylib/game_of_life $FLAGS
           odin check raylib/log $FLAGS

--- a/math/rand/markov/simple_markov.odin
+++ b/math/rand/markov/simple_markov.odin
@@ -1,0 +1,41 @@
+package main
+
+import "core:fmt"
+import "core:math/rand"
+
+// Illustrating a simple first-order markov chain, leveraging some Odin features.
+
+State :: enum { Banana, Apple, Pear, Lime, Blueberry }
+
+Transition_Matrix := [State][State]f64{
+	.Banana     = {.Banana = 0.30, .Apple = 0.25, .Pear = 0.25, .Lime = 0.10, .Blueberry = 0.10},
+	.Apple      = {.Banana = 0.10, .Apple = 0.25, .Pear = 0.32, .Lime = 0.13, .Blueberry = 0.20},
+	.Pear       = {.Banana = 0.40, .Apple = 0.15, .Pear = 0.25, .Lime = 0.10, .Blueberry = 0.10},
+	.Lime       = {.Banana = 0.05, .Apple = 0.05, .Pear = 0.25, .Lime = 0.35, .Blueberry = 0.30},
+	.Blueberry  = {.Banana = 0.20, .Apple = 0.25, .Pear = 0.25, .Lime = 0.10, .Blueberry = 0.10},
+}
+
+main :: proc() {
+	cur_state, prev_state: State
+
+	for i in 1..=50 {
+		cur_state = next_state(cur_state)
+		fmt.printfln("State transition %v: %v -> %v", i, prev_state, cur_state)
+		prev_state = cur_state
+	}
+}
+
+next_state :: proc(cur_state: State) -> State {
+	chance := rand.float64()
+	accumulate: f64
+
+	for s in State {
+		accumulate += Transition_Matrix[cur_state][s]
+		
+		if chance < accumulate {
+			return s
+		}
+	}
+
+	return cur_state
+}


### PR DESCRIPTION
<!-- use [x] to mark the item as done -->

Example of a first-order markov chain using rand, leveraging other Odin features.

Checklist before submitting:
- [X] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [X] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [X] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [X] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
