### PR TITLE
Small bugfix in windows raw_console

### DIFF
--- a/console/raw_console/main.odin
+++ b/console/raw_console/main.odin
@@ -23,11 +23,17 @@ get_password :: proc(allocator := context.allocator) -> string {
 			fmt.eprintfln("\nError: %v", err)
 			os.exit(1)
 
-		case ch == '\n':
+		// End line
+		case ch == '\n': // Posix
+			fallthrough
+		case ch == '\r': // Windows
 			fmt.println()
 			return string(buf[:])
 
-		case ch == '\u007f': // Backspace.
+		// Backspace
+		case ch == '\u007f': // Posix
+			fallthrough
+		case ch == '\b':     // Windows
 			_, bs_sz := utf8.decode_last_rune(buf[:])	
 			if bs_sz > 0 {
 				resize(&buf, len(buf)-bs_sz)


### PR DESCRIPTION
Backspace and newline characters weren't being recognized

<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
