### PR TITLE
Update generate_image_info.odin to add file mode

### DIFF
--- a/code_generation/generate_image_info/generate_image_info.odin
+++ b/code_generation/generate_image_info/generate_image_info.odin
@@ -33,7 +33,7 @@ main :: proc() {
 
 	input_files, _ := os.read_dir(d, -1)
 
-	f, _ := os.open(OUTPUT_FILE, os.O_WRONLY | os.O_CREATE | os.O_TRUNC)
+	f, _ := os.open(OUTPUT_FILE, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0o644)
 	defer os.close(f)
 
 	images: [dynamic]os.File_Info


### PR DESCRIPTION
otherwise the generated file mode will be 0x000.

<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
