### PR TITLE
Fix typo

### DIFF
--- a/absolute_beginners/3_loops.odin
+++ b/absolute_beginners/3_loops.odin
@@ -17,7 +17,7 @@ loops :: proc(n: int) -> int {
 
 	// Let's make a loop that runs 5 times! You can do that in several ways.
 
-	// This loops from 0 to 5 and for each lap of the loop the number is
+	// This loops from 0 to 4 and for each lap of the loop the number is
 	// availble in the loop variable `i`.
 	for i in 0..<5 {
 		fmt.println(i) // 0, 1, 2, 3, 4


### PR DESCRIPTION
I do not know if the intention of this description is to say that the `i` variable internally might reach the number 5 (I do not know if this is the case internally for ranges, just speculating).

But, in any case, for absolute beginners who have not even see the C-style `for` that comes next, I believe looping from 0 to 4 would be the natural thing to say, and matches the "0, 1, 2, 3, 4" comment in the example itself.

This examples repository is awesome, thanks for it.

<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
