### PR TITLE
Fix file name of nanovg odin run command comment

### DIFF
--- a/nanovg/example.odin
+++ b/nanovg/example.odin
@@ -2,7 +2,7 @@ package main
 
 /*
 Original Source: https://github.com/memononen/nanovg/blob/master/example/example_gl3.c
-Can be run using: odin.exe run main.odin -file
+Can be run using: odin.exe run example.odin -file
 */
 
 import "core:fmt"


### PR DESCRIPTION
It should be example.odin, not main.odin.
Seems the file was renamed since.

<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing):
  - Was already the case: https://github.com/duchainer/odin-lang--examples/blob/nanovg--fix-typo-in-odin-run-comment/.github/workflows/check.yml#L124
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
  - I had to simlink my libglfw.so.3 to libglfw.so, then it worked.
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
  - I only adjusted so that the file name in the comment matched the existing file name
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
