### PR TITLE
Added core-basic-window raylib example

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,6 +76,7 @@ jobs:
           odin check raylib/ports/textures/textures_gif_player.odin -file $FLAGS
           odin check raylib/tetroid $FLAGS
           odin check raylib/box2d $FLAGS
+          odin check raylib/ports/core/core_basic_window.odin -file $FLAGS
 
           odin check directx/d3d11_minimal_sdl2 -target:windows_amd64 $FLAGS
 

--- a/raylib/ports/core/core_basic_window.odin
+++ b/raylib/ports/core/core_basic_window.odin
@@ -1,0 +1,70 @@
+/*******************************************************************************************
+*
+*   raylib [core] example - basic window
+*
+*   Example complexity rating: [★☆☆☆] 1/4
+*
+*   Welcome to raylib!
+*
+*   To test examples, just press F6 and execute 'raylib_compile_execute' script
+*   Note that compiled executable is placed in the same folder as .c file
+*
+*   To test the examples on Web, press F6 and execute 'raylib_compile_execute_web' script
+*   Web version of the program is generated in the same folder as .c file
+*
+*   You can find all basic examples on C:\raylib\raylib\examples folder or
+*   raylib official webpage: www.raylib.com
+*
+*   Enjoy using raylib. :)
+*
+*   Example originally created with raylib 1.0, last time updated with raylib 1.0
+*
+*   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
+*   BSD-like license that allows static linking with closed source software
+*
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
+*
+********************************************************************************************/
+
+package raylib_examples
+
+import rl "vendor:raylib"
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+main :: proc() {
+	// Initialization
+	//--------------------------------------------------------------------------------------
+	SCREEN_WIDTH :: 800
+	SCREEN_HEIGHT :: 450
+
+	rl.InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "raylib [core] example - basic window")
+
+	rl.SetTargetFPS(60) 				// Set our game to run at 60 frames-per-second
+	//--------------------------------------------------------------------------------------
+
+	// Main game loop
+	for !rl.WindowShouldClose() { 		// Detect window close button or ESC key
+		// Update
+		//----------------------------------------------------------------------------------
+		// TODO: Update your variables here
+		//----------------------------------------------------------------------------------
+
+		// Draw
+		//----------------------------------------------------------------------------------
+		rl.BeginDrawing()
+
+			rl.ClearBackground(rl.RAYWHITE)
+
+			rl.DrawText("Congrats! You created your first window!", 190, 200, 20, rl.LIGHTGRAY)
+
+		rl.EndDrawing()
+		//----------------------------------------------------------------------------------
+	}
+
+	// De-Initialization
+	//--------------------------------------------------------------------------------------
+	rl.CloseWindow() // Close window and OpenGL context
+	//--------------------------------------------------------------------------------------
+}


### PR DESCRIPTION
Added `core-basic-window` raylib example which is based on [core_basic_window.c](https://www.raylib.com/examples/core/loader.html?name=core_basic_window)

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example follows the `core` naming convention: https://github.com/odin-lang/Odin/wiki/Naming-Convention (exception can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's BSD-3 license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
