### PR TITLE
Updated win32 manifest example for added bindings in new Odin version.

### DIFF
--- a/win32/embedded_manifest/main.odin
+++ b/win32/embedded_manifest/main.odin
@@ -52,27 +52,20 @@ wndproc :: proc "system"(hwnd: win.HWND, msg: win.UINT, wparam: win.WPARAM, lpar
 			10, 10, 150, 30,
 			hwnd, nil, nil, nil)
 		assert(button != nil, "Button creation failed")
-		// This is a really crufty way of detecting whether Common Controls v6 is enabled.
-		// It may or may not work reliably on your system.
-		// Do NOT use this.
-		if GetWindowTheme(button) != nil {
+
+		// In addition to the change in visual appearance of the button we just created,
+		// we *attempt* to detect programmatically whether we've successfully linked to Common Controls v6.
+		// However, this is not an intended use case, so it may or may not work reliably on your system.
+		// Do NOT use this in production code.
+		if win.GetWindowTheme(button) != nil {
+			// Common Controls v6 is probably linked successfully.
 			win.SetWindowTextW(button, "Modern button")
 		} else {
+			// Common Controls v6 is probably not linked successfully.
 			win.SetWindowTextW(button, "Dated button")
 		}
 	case win.WM_DESTROY:
 		win.PostQuitMessage(0)
 	}
 	return win.DefWindowProcW(hwnd, msg, wparam, lparam)
-}
-
-// NOTE: The following should probably be merged upstream into core:sys/windows
-
-HTHEME :: distinct win.HANDLE
-
-foreign import uxtheme "system:uxtheme.lib"
-
-@(default_calling_convention="system")
-foreign uxtheme {
-	GetWindowTheme :: proc(hwnd: win.HWND) -> HTHEME ---
 }


### PR DESCRIPTION
This was still pending after the initial commit of this example, since Odin's release build at the time was missing some required win32 bindings.

Also, I clarified the comment about the imperfect theme detection code, after valid criticism.

<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example the naming and style convention: https://github.com/odin-lang/examples/wiki/Naming-and-style-convention (exceptions can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's zlib license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
