### PR TITLE
add miniaudio example port

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -177,4 +177,4 @@ jobs:
           odin check net/udp_echo_server/client $FLAGS
           odin check net/udp_echo_server/server $FLAGS
 
-          odin check miniaudio/simple_playback -file $FLAGS
+          odin check miniaudio/ports/simple_playback.odin -target:windows_amd64 -file $FLAGS

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -176,3 +176,5 @@ jobs:
 
           odin check net/udp_echo_server/client $FLAGS
           odin check net/udp_echo_server/server $FLAGS
+
+          odin check miniaudio/simple_playback -file $FLAGS

--- a/miniaudio/ports/README.md
+++ b/miniaudio/ports/README.md
@@ -1,0 +1,5 @@
+These are ports of the official miniaudio examples found [here](https://github.com/mackron/miniaudio/tree/master/examples).
+
+Because we mirror the structure of the original examples, they need to be run with `-file`.
+
+For example, to run the `simple_playback.odin` example: `odin run miniaudio/simple_playback.odin -file`

--- a/miniaudio/ports/simple_playback.odin
+++ b/miniaudio/ports/simple_playback.odin
@@ -1,0 +1,60 @@
+package main
+
+import "base:runtime"
+
+import "core:fmt"
+import "core:os"
+
+import ma "vendor:miniaudio"
+
+data_callback :: proc "c" (device: ^ma.device, output: rawptr, input: rawptr, frame_count: u32) {
+	decoder := (^ma.decoder)(device.pUserData)
+	if decoder == nil {
+		return
+	}
+
+	ma.decoder_read_pcm_frames(decoder, output, u64(frame_count), nil)
+}
+
+main :: proc() {
+	args := runtime.args__
+	if len(args) < 2 {
+		fmt.eprintfln("No input file.")
+		os.exit(-1)
+	}
+
+	decoder: ma.decoder
+	result := ma.decoder_init_file(args[1], nil, &decoder)
+	if result != .SUCCESS {
+		fmt.eprintfln("Could not load file: %s", args[1])
+		os.exit(-2)
+	}
+
+	device_config := ma.device_config_init(.playback)
+	device_config.playback.format   = decoder.outputFormat
+	device_config.playback.channels = decoder.outputChannels
+	device_config.sampleRate        = decoder.outputSampleRate
+	device_config.dataCallback      = data_callback
+	device_config.pUserData         = &decoder
+
+	device: ma.device
+	if ma.device_init(nil, &device_config, &device) != .SUCCESS {
+		fmt.eprintfln("Failed to open playback device.")
+		ma.decoder_uninit(&decoder)
+		os.exit(-3)
+	}
+
+	if ma.device_start(&device) != .SUCCESS {
+		fmt.eprintfln("Failed to start playback device.")
+		ma.device_uninit(&device)
+		ma.decoder_uninit(&decoder)
+		os.exit(-4)
+	}
+
+	fmt.printfln("Press Enter to quit...")
+	p: [1]byte
+	os.read(os.stdin, p[:])
+
+	ma.device_uninit(&device)
+	ma.decoder_uninit(&decoder)
+}


### PR DESCRIPTION
<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example the naming and style convention: https://github.com/odin-lang/examples/wiki/Naming-and-style-convention (exceptions can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's zlib license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
