### PR TITLE
Fix validation errors in Vulkan sample

### DIFF
--- a/vulkan/triangle_glfw/main.odin
+++ b/vulkan/triangle_glfw/main.odin
@@ -802,7 +802,7 @@ create_swapchain :: proc() {
 			must(vk.CreateImageView(g_device, &create_info, nil, &g_swapchain_views[i]))
 
 			semaphore_ci := vk.SemaphoreCreateInfo {
-				sType = .SEMAPHORE_CREATE_INFO
+				sType = .SEMAPHORE_CREATE_INFO,
 			}
 			must(vk.CreateSemaphore(g_device, &semaphore_ci, nil, &g_render_finished_semaphores[i]))
 		}

--- a/vulkan/triangle_glfw/main.odin
+++ b/vulkan/triangle_glfw/main.odin
@@ -80,7 +80,7 @@ g_command_pool: vk.CommandPool
 g_command_buffers: [MAX_FRAMES_IN_FLIGHT]vk.CommandBuffer
 
 g_image_available_semaphores: [MAX_FRAMES_IN_FLIGHT]vk.Semaphore
-g_render_finished_semaphores: [MAX_FRAMES_IN_FLIGHT]vk.Semaphore
+g_render_finished_semaphores: []vk.Semaphore
 g_in_flight_fences: [MAX_FRAMES_IN_FLIGHT]vk.Fence
 
 // KHR_PORTABILITY_SUBSET_EXTENSION_NAME :: "VK_KHR_portability_subset"
@@ -161,7 +161,7 @@ main :: proc() {
 		dbg_create_info := vk.DebugUtilsMessengerCreateInfoEXT {
 			sType           = .DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
 			messageSeverity = severity,
-			messageType     = {.GENERAL, .VALIDATION, .PERFORMANCE, .DEVICE_ADDRESS_BINDING}, // all of them.
+			messageType     = {.GENERAL, .VALIDATION, .PERFORMANCE },
 			pfnUserCallback = vk_messenger_callback,
 		}
 		create_info.pNext = &dbg_create_info
@@ -212,8 +212,6 @@ main :: proc() {
 			sType                   = .DEVICE_CREATE_INFO,
 			pQueueCreateInfos       = raw_data(queue_create_infos),
 			queueCreateInfoCount    = u32(len(queue_create_infos)),
-			enabledLayerCount       = create_info.enabledLayerCount,
-			ppEnabledLayerNames     = create_info.ppEnabledLayerNames,
 			ppEnabledExtensionNames = raw_data(DEVICE_EXTENSIONS),
 			enabledExtensionCount   = u32(len(DEVICE_EXTENSIONS)),
 		}
@@ -403,12 +401,10 @@ main :: proc() {
 		}
 		for i in 0 ..< MAX_FRAMES_IN_FLIGHT {
 			must(vk.CreateSemaphore(g_device, &sem_info, nil, &g_image_available_semaphores[i]))
-			must(vk.CreateSemaphore(g_device, &sem_info, nil, &g_render_finished_semaphores[i]))
 			must(vk.CreateFence(g_device, &fence_info, nil, &g_in_flight_fences[i]))
 		}
 	}
 	defer for sem in g_image_available_semaphores {vk.DestroySemaphore(g_device, sem, nil)}
-	defer for sem in g_render_finished_semaphores {vk.DestroySemaphore(g_device, sem, nil)}
 	defer for fence in g_in_flight_fences {vk.DestroyFence(g_device, fence, nil)}
 
 	current_frame := 0
@@ -453,7 +449,7 @@ main :: proc() {
 			commandBufferCount   = 1,
 			pCommandBuffers      = &g_command_buffers[current_frame],
 			signalSemaphoreCount = 1,
-			pSignalSemaphores    = &g_render_finished_semaphores[current_frame],
+			pSignalSemaphores    = &g_render_finished_semaphores[image_index],
 		}
 		must(vk.QueueSubmit(g_graphics_queue, 1, &submit_info, g_in_flight_fences[current_frame]))
 
@@ -461,7 +457,7 @@ main :: proc() {
 		present_info := vk.PresentInfoKHR {
 			sType              = .PRESENT_INFO_KHR,
 			waitSemaphoreCount = 1,
-			pWaitSemaphores    = &g_render_finished_semaphores[current_frame],
+			pWaitSemaphores    = &g_render_finished_semaphores[image_index],
 			swapchainCount     = 1,
 			pSwapchains        = &g_swapchain,
 			pImageIndices      = &image_index,
@@ -792,6 +788,7 @@ create_swapchain :: proc() {
 
 		g_swapchain_images = make([]vk.Image, count)
 		g_swapchain_views = make([]vk.ImageView, count)
+		g_render_finished_semaphores = make([]vk.Semaphore, count)
 		must(vk.GetSwapchainImagesKHR(g_device, g_swapchain, &count, raw_data(g_swapchain_images)))
 
 		for image, i in g_swapchain_images {
@@ -803,16 +800,23 @@ create_swapchain :: proc() {
 				subresourceRange = {aspectMask = {.COLOR}, levelCount = 1, layerCount = 1},
 			}
 			must(vk.CreateImageView(g_device, &create_info, nil, &g_swapchain_views[i]))
+
+			semaphore_ci := vk.SemaphoreCreateInfo {
+				sType = .SEMAPHORE_CREATE_INFO
+			}
+			must(vk.CreateSemaphore(g_device, &semaphore_ci, nil, &g_render_finished_semaphores[i]))
 		}
 	}
 }
 
 destroy_swapchain :: proc() {
-	for view in g_swapchain_views {
+	for view, i in g_swapchain_views {
 		vk.DestroyImageView(g_device, view, nil)
+		vk.DestroySemaphore(g_device, g_render_finished_semaphores[i], nil)
 	}
 	delete(g_swapchain_views)
 	delete(g_swapchain_images)
+	delete(g_render_finished_semaphores)
 	vk.DestroySwapchainKHR(g_device, g_swapchain, nil)
 }
 

--- a/vulkan/triangle_glfw/main.odin
+++ b/vulkan/triangle_glfw/main.odin
@@ -161,7 +161,7 @@ main :: proc() {
 		dbg_create_info := vk.DebugUtilsMessengerCreateInfoEXT {
 			sType           = .DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
 			messageSeverity = severity,
-			messageType     = {.GENERAL, .VALIDATION, .PERFORMANCE },
+			messageType     = {.GENERAL, .VALIDATION, .PERFORMANCE},
 			pfnUserCallback = vk_messenger_callback,
 		}
 		create_info.pNext = &dbg_create_info


### PR DESCRIPTION
This pull request implements the following changes to fix validation errors:

Allocated `g_render_finished_semaphores` dynamically based on swapchain image count and index it using swapchain image index instead of frame in flight index.  See [https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html](https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html):
```
vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0x170000000017) is being signaled by VkQueue 0x181c21214d0, but it may still be in use by VkSwapchainKHR 0x30000000003.
Most recently acquired image indices: 0, [1], 2, 0.
(Brackets mark the last use of VkSemaphore 0x170000000017 in a presentation operation.)
Swapchain image 1 was presented but was not re-acquired, so VkSemaphore 0x170000000017 may still be in use and cannot be safely reused with image index 0.
Hint: See https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html for details on swapchain semaphore reuse. Examples of possible approaches:
   a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
   b) Consider the VK_KHR_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: Each binary semaphore element of the pSignalSemaphores member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit-pSignalSemaphores-00067)
```

Removed `VK_DEBUG_UTILS_MESSAGE_TYPE_DEVICE_ADDRESS_BINDING_BIT_EXT` from `DebugUtilsMessengerCreateInfoEXT`as it requires `VK_EXT_device_address_binding_report`:
```
vkCreateInstance(): pCreateInfo->pNext<VkDebugUtilsMessengerCreateInfoEXT>.messageType has VkDebugUtilsMessageTypeFlagBitsEXT values (VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT|VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT|VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT|VK_DEBUG_UTILS_MESSAGE_TYPE_DEVICE_ADDRESS_BINDING_BIT_EXT) that requires the extensions VK_EXT_device_address_binding_report.
The Vulkan spec states: messageType must be a valid combination of VkDebugUtilsMessageTypeFlagBitsEXT values (https://docs.vulkan.org/spec/latest/chapters/debugging.html#VUID-VkDebugUtilsMessengerCreateInfoEXT-messageType-parameter)
```

Removed layers from device creation:
```
vkCreateDevice(): pCreateInfo->enabledLayerCount is 1 (not zero).
Device Layers have never worked since Vulkan 1.0 and only Instance Layers should be used instead: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-devicelayers.
The Vulkan spec states: enabledLayerCount must be 0 (https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VUID-VkDeviceCreateInfo-enabledLayerCount-12384)
```

<!-- use [x] to mark the item as done -->

Checklist before submitting:
- [x] This example has been added to `.github/workflows/check.yml` (for automatic testing)
- [x] This example compiles cleanly with flags `-vet -strict-style -vet-tabs -disallow-do -warnings-as-errors`
- [x] This example the naming and style convention: https://github.com/odin-lang/examples/wiki/Naming-and-style-convention (exceptions can be made for ports of examples that need to match 1:1 to the original source).
- [x] By submitting, I understand that this example is made available under these licenses: [Public Domain](https://unlicense.org) and [Odin's zlib license](https://github.com/odin-lang/Odin/blob/master/LICENSE). Only for third-party dependencies are other licenses allowed.
